### PR TITLE
Beautiful error messages with `codespan-reporting`

### DIFF
--- a/configure_me_codegen/Cargo.toml
+++ b/configure_me_codegen/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 [features]
 default = ["man"]
 debconf = []
+spanned = ["codespan-reporting"]
 unstable-metabuild = []
 
 [dependencies]
@@ -25,6 +26,8 @@ unicode-segmentation = "1.2"
 fmt2io = "0.1"
 void = "1"
 man = { version = "0.1.1", optional = true }
+# This feature is not public! Do not depend on it, depend on `spanned` instead!
+codespan-reporting = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
 configure_me = { version = "0.4.0", path = "../configure_me" }

--- a/configure_me_codegen/src/config.rs
+++ b/configure_me_codegen/src/config.rs
@@ -1,78 +1,229 @@
 use std::fmt;
 
 #[derive(Debug)]
-pub enum ValidationErrorKind {
-    MandatoryWithDefault,
-    InvertedWithAbbr,
-    InvertedWithCount,
-    InvalidAbbr,
-    Duplicate,
+pub enum FieldError {
+    MandatoryWithDefault { optional_span: Span, default_span: Span, },
+    InvertedWithAbbr { default_span: Span, abbr_span: Span, },
+    InvertedWithCount { default_span: Span, count_span: Span, },
+    InvalidAbbr { abbr_span: Span, },
+    ReservedParameter,
 }
 
 #[derive(Debug)]
 pub struct ValidationError {
-    name: String,
-    kind: ValidationErrorKind,
+    source: ValidationErrorSource,
 }
+
+impl ValidationError {
+    // We sort by the span.start of the first root cause
+    fn sort_key(&self) -> usize {
+        use self::FieldError::*;
+        use self::ValidationErrorSource::*;
+
+        match &self.source {
+            InvalidField { kind: MandatoryWithDefault { optional_span, default_span }, .. } => optional_span.start.min(default_span.start),
+            InvalidField { kind: InvertedWithAbbr { abbr_span, default_span }, .. } => abbr_span.start.min(default_span.start),
+            InvalidField { kind: InvertedWithCount { count_span, default_span }, .. } => count_span.start.min(default_span.start),
+            InvalidField { kind: InvalidAbbr { abbr_span }, .. } => abbr_span.start,
+            InvalidField { kind: ReservedParameter, span, .. } => span.start,
+            Duplicates { duplicate_spans, .. } => duplicate_spans[0].start, // always non-empty
+            InvalidIdentifier(error) => error.span().start
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ValidationErrorSource {
+    InvalidField { name: String, span: Span, kind: FieldError },
+    Duplicates { name: String, first_span: Span, duplicate_spans: Vec<Span> },
+    InvalidIdentifier(ident::Error),
+}
+
+impl From<ident::Error> for ValidationError {
+    fn from(value: ident::Error) -> Self {
+        ValidationError { source: ValidationErrorSource::InvalidIdentifier(value) }
+    }
+}
+
 
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ValidationErrorKind::*;
+        use self::FieldError::*;
+        use self::ValidationErrorSource::*;
 
-        let msg = match self.kind {
-            MandatoryWithDefault => "parameter with default value must be optional",
-            InvertedWithAbbr => "inverted switch can't have short option",
-            InvertedWithCount => "inverted switch can't be count",
-            InvalidAbbr => "invalid short switch: must be [a-zA-Z]",
-            Duplicate => "the field appears more than once",
-        };
+        match &self.source {
+            InvalidField { name, kind, .. } => {
+                let msg = match kind {
+                    MandatoryWithDefault { .. } => "parameter with default value must be optional",
+                    InvertedWithAbbr { .. } => "inverted switch can't have a short option",
+                    InvertedWithCount { .. } => "inverted switch can't be a count",
+                    InvalidAbbr { .. } => "invalid short switch: must be [a-zA-Z]",
+                    ReservedParameter => "this parameter is reserved and always implemented by configure_me",
+                };
+                write!(f, "invalid configuration for field {}: {}", name, msg)
+            },
+            // first span is stored separately so we have to add 1
+            Duplicates { name, duplicate_spans, .. } => write!(f, "the option {} occurs {} times", name, duplicate_spans.len() + 1),
+            InvalidIdentifier(error) => fmt::Display::fmt(error, f),
+        }
+    }
+}
 
-        write!(f, "invalid configuration for field {}: {}", self.name, msg)
+#[cfg(feature = "spanned")]
+impl ValidationError {
+    pub fn to_diagnostic<T: Copy>(&self, file_id: T) -> codespan_reporting::diagnostic::Diagnostic<T> {
+        use self::FieldError::*;
+        use codespan_reporting::diagnostic::Label;
+
+        let diagnostic = codespan_reporting::diagnostic::Diagnostic::error();
+        match &self.source {
+            ValidationErrorSource::InvalidField { name, span, kind } => {
+                match kind {
+                    MandatoryWithDefault { optional_span, default_span } => {
+                        diagnostic
+                            .with_message("parameter attempts to be both optional and mandatory at the same time")
+                            .with_labels(vec![
+                                 Label::primary(file_id, *optional_span).with_message("setting `optional` to `false` makes the parameter mandatory here"),
+                                 Label::primary(file_id, *default_span).with_message("the default value is provided here making the parameter optional"),
+                                 Label::secondary(file_id, *span).with_message(format!("in the parameter `{}`", name)),
+                            ])
+                            .with_notes(vec![
+                                "Help: either make the parameter optional or remove the default value".to_owned()
+                            ])
+                    },
+                    InvertedWithAbbr { default_span, abbr_span } => {
+                        diagnostic
+                            .with_message("an inverted switch attempts to have a short option")
+                            .with_labels(vec![
+                                 Label::primary(file_id, *abbr_span).with_message("short option defined here"),
+                                 Label::primary(file_id, *default_span).with_message("the default value is set to `true` here making the switch inverted"),
+                                 Label::secondary(file_id, *span).with_message(format!("in the parameter `{}`", name)),
+                            ])
+                            .with_notes(vec![
+                                "Help: remove the short option if you want to keep the parameter inverted".to_owned()
+                            ])
+                    },
+                    InvertedWithCount { default_span, count_span } => {
+                        diagnostic.with_message("inverted switch attempts to be a counter")
+                            .with_labels(vec![
+                                 Label::primary(file_id, *count_span).with_message("counter defined here"),
+                                 Label::primary(file_id, *default_span).with_message("the default value is set to `true` here making the switch inverted"),
+                                 Label::secondary(file_id, *span).with_message(format!("in the parameter `{}`", name)),
+                            ])
+                            .with_notes(vec![
+                                "Help: either don't make the parameter counter or make the parameter non-inverted".to_owned()
+                            ])
+                    },
+                    InvalidAbbr { abbr_span } => {
+                        diagnostic
+                            .with_message("invalid short option")
+                            .with_labels(vec![
+                                 Label::primary(file_id, *abbr_span).with_message("this option uses an invalid character"),
+                                 Label::secondary(file_id, *span).with_message("in this field"),
+                            ])
+                            .with_notes(vec![
+                                "Note: only English letters (both lower case and upper case) are allowed".to_owned()
+                            ])
+                    },
+                    ReservedParameter => {
+                        diagnostic
+                            .with_message("use of reserved option")
+                            .with_labels(vec![
+                                 Label::primary(file_id, *span).with_message("this option is reserved because it's always implemented by `configure_me`"),
+                            ])
+                    },
+                }
+            },
+            ValidationErrorSource::Duplicates { first_span, duplicate_spans, name } => {
+                let mut labels = Vec::with_capacity(duplicate_spans.len() + 1);
+                labels.push(Label::secondary(file_id, *first_span).with_message("the option was first defined here"));
+                let mut iter = duplicate_spans.iter();
+                let first_dup_span = *iter.next().expect("at least one duplicate");
+                labels.push(Label::primary(file_id, first_dup_span).with_message("the option is repeated here"));
+                labels.extend(iter.map(|span| Label::primary(file_id, *span).with_message("... and here")));
+                diagnostic
+                    .with_message(format!("the option `{}` appears more than once", name))
+                    .with_labels(labels)
+            },
+            ValidationErrorSource::InvalidIdentifier(error) => error.to_diagnostic(file_id),
+        }
     }
 }
 
 mod ident {
     use std::convert::TryFrom;
     use std::fmt::{self, Write};
+    use super::Span;
+    use toml::Spanned;
 
     #[derive(Debug)]
-    pub struct Error {
-        string: String,
-        position: usize,
+    pub enum Error {
+        InvalidChars {
+            string: String,
+            positions: Vec<usize>,
+            span: Span,
+        },
+        Empty { span: Span, }
     }
 
     impl fmt::Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "\"{}\" is not a valid identifier, invalid char at position {}", self.string, self.position)
+            match self {
+                Error::InvalidChars { string, positions, .. } if positions.len() == 1 => write!(f, "\"{}\" is not a valid identifier, invalid char at position {}", string, positions[0]),
+                Error::InvalidChars { string, positions, .. } => {
+                    let mut iter = positions.iter();
+                    write!(f, "\"{}\" is not a valid identifier, invalid chars at positions: {}", string, iter.next().expect("always at least one"))?;
+                    for pos in iter {
+                        write!(f, ", {}", pos)?;
+                    }
+                    Ok(())
+                },
+                Error::Empty { .. } => write!(f, "the identifier is empty"),
+            }
         }
     }
 
-    #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
-    #[serde(try_from = "String")]
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     pub struct Ident(String);
 
-    impl TryFrom<String> for Ident {
+    impl TryFrom<Spanned<String>> for Ident {
         type Error = Error;
 
-        fn try_from(string: String) -> Result<Ident, Error> {
-            let bad_char = string
-                .chars()
-                .enumerate()
-                .find(|&(i, c)| c != '_' && ! ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9' && i > 0)));
+        fn try_from(string: Spanned<String>) -> Result<Ident, Error> {
+            let span = Span::from(&string);
+            let string = string.into_inner();
 
-            match bad_char {
-                Some((i, _)) => {
-                    Err(Error {
-                        string,
-                        position: i,
-                    })
-                },
-                None => Ok(Ident(string)),
+            if string.is_empty() {
+                return Err(Error::Empty { span, })
+            }
+
+            match Self::validate(&string) {
+                Ok(()) => Ok(Ident(string)),
+                Err(positions) => Err(Error::InvalidChars {
+                    string,
+                    positions,
+                    span,
+                }),
             }
         }
     }
 
     impl Ident {
+        fn validate(string: &str) -> Result<(), Vec<usize>> {
+            let invalid_chars_positions = string
+                .chars()
+                .enumerate()
+                .filter(|&(i, c)| c != '_' && ! ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9' && i > 0)))
+                .map(|(i, _)| i)
+                .collect::<Vec<_>>();
+
+            if invalid_chars_positions.is_empty() {
+                Ok(())
+            } else {
+                Err(invalid_chars_positions)
+            }
+        }
+
         pub(crate) fn as_snake_case(&self) -> &str {
             &self.0
         }
@@ -134,26 +285,232 @@ mod ident {
             Ok(())
         }
     }
+
+    impl Error {
+        pub fn span(&self) -> Span {
+            match self {
+                Error::InvalidChars { span, .. } => *span,
+                Error::Empty { span, .. } => *span,
+            }
+        }
+
+        #[cfg(feature = "spanned")]
+        pub fn to_diagnostic<T: Copy>(&self, file_id: T) -> codespan_reporting::diagnostic::Diagnostic<T> {
+            use codespan_reporting::diagnostic::Label;
+
+            let create_label = |start, end, was_emitted| {
+                let label = Label::primary(file_id, start..end);
+                match (end - start > 1, was_emitted) {
+                    (false, false) => label.with_message("this char is invalid"),
+                    (false, true) => label.with_message("... and this char"),
+                    (true, false) => label.with_message("these chars are invalid"),
+                    (true, true) => label.with_message("... and these chars"),
+                }
+            };
+
+            match self {
+                Error::InvalidChars { string, positions, span } => {
+                    // this may over-allocate but it's better to be fast than memory-saving
+                    let mut labels = Vec::with_capacity(positions.len());
+                    let mut positions = positions.iter();
+                    let diagnostic = codespan_reporting::diagnostic::Diagnostic::error();
+                    let diagnostic = if positions.len() > 1 {
+                        diagnostic.with_message(format!("the identifier `{}` contains invalid characters", string))
+                    } else {
+                        diagnostic.with_message(format!("the identifier `{}` contains an invalid character", string))
+                    };
+
+                    // first one is special
+                    let diagnostic = if string.starts_with(|c| c >= '0' && c <= '9') {
+                        labels.push(Label::primary(file_id, (span.start + 1)..(span.start + 2)).with_message("the identifier starts with a digit"));
+                        positions.next().expect("starting with zero is recorded");
+                        diagnostic.with_notes(vec!["Help: identifiers mut not start with digits".to_owned()])
+                    } else if string.starts_with('-') {
+                        diagnostic.with_notes(vec!["Help: dashes are prepended automatically, you don't need to write them".to_owned()])
+                    } else {
+                        diagnostic
+                    };
+
+                    let contains_dashes_not_at_start = string
+                        .chars()
+                        .skip_while(|c| *c == '-')
+                        .any(|c| c == '-');
+
+                    let diagnostic = if contains_dashes_not_at_start {
+                        diagnostic.with_notes(vec!["Help: consider replacing dashes with underscores.\n      They will be replaced with dashes in command line parameters\n      but stay underscores in config files.".to_owned()])
+                    } else {
+                        diagnostic
+                    };
+
+                    if let Some(first) = positions.next() {
+                        let mut last_start = *first;
+                        let mut last_end = *first + 1;
+                        let mut was_emitted = false;
+                        for position in positions {
+                            if *position == last_end {
+                                last_end += 1;
+                            } else {
+                                labels.push(create_label(span.start + last_start + 1, span.start + last_end + 1, was_emitted));
+                                was_emitted = true;
+                                last_start = *position;
+                                last_end = *position + 1;
+                            }
+                        }
+                        labels.push(create_label(span.start + last_start + 1, span.start + last_end + 1, was_emitted));
+                    }
+
+                    diagnostic
+                        .with_labels(labels)
+                },
+                Error::Empty { span } => {
+                    codespan_reporting::diagnostic::Diagnostic::error()
+                        .with_message("encountered an empty identifier")
+                        .with_labels(vec![
+                                     Label::primary(file_id, *span)
+                                         .with_message("this identifier is empty")
+                        ])
+                },
+            }
+        }
+    }
 }
 
 use self::ident::Ident;
 
+#[derive(Debug, Copy, Clone)]
+pub struct Span {
+    start: usize,
+    end: usize,
+}
+
+impl From<Span> for core::ops::Range<usize> {
+    fn from(value: Span) -> Self {
+        value.start..value.end
+    }
+}
+
 pub mod raw {
+    use toml::Spanned;
     use std::convert::TryFrom;
-    use super::{ValidationError, ValidationErrorKind, Optionality, SwitchKind};
+    use super::{ValidationError, FieldError, ValidationErrorSource, Optionality, SwitchKind};
     use super::ident::Ident;
+    use super::Span;
+
+    impl<'a, T> From<&'a Spanned<T>> for Span {
+        fn from(value: &'a Spanned<T>) -> Self {
+            Span {
+                start: value.start(),
+                end: value.end(),
+            }
+        }
+    }
 
     trait ResultExt {
         type Item;
 
-        fn field_name(self, name: &Ident) -> Result<Self::Item, ValidationError>;
+        fn field_name(self, name: &Spanned<String>) -> Result<Self::Item, ValidationError>;
     }
 
-    impl<T> ResultExt for Result<T, ValidationErrorKind> {
+    impl<T> ResultExt for Result<T, FieldError> {
         type Item = T;
 
-        fn field_name(self, name: &Ident) -> Result<Self::Item, ValidationError> {
-            self.map_err(|kind| ValidationError { name: name.as_snake_case().to_owned(), kind })
+        fn field_name(self, name: &Spanned<String>) -> Result<Self::Item, ValidationError> {
+            let span = Span::from(name);
+            self.map_err(|kind| ValidationError { source: ValidationErrorSource::InvalidField { name: name.get_ref().clone(), span, kind }})
+        }
+    }
+
+    struct ArgValidator<T: Eq + std::hash::Hash> {
+        // just for checking, order/determinism doesn't matter
+        map: std::collections::HashMap<T, Option<Span>>,
+        dup_cache: std::collections::HashMap<T, (Span, Vec<Span>)>,
+    }
+
+    impl<T: Eq + std::hash::Hash + Clone> ArgValidator<T> {
+        fn with_reserved(arg: T) -> Self {
+            let mut map = std::collections::HashMap::new();
+            map.insert(arg, None);
+
+            ArgValidator {
+                map,
+                dup_cache: Default::default(),
+            }
+        }
+
+        fn check_insert(&mut self, arg: &Spanned<T>) -> Result<(), FieldError> {
+            use std::collections::hash_map::Entry;
+
+            match self.map.entry(arg.get_ref().clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(Some(Span::from(arg)));
+                    Ok(())
+                },
+                Entry::Occupied(entry) => {
+                    match entry.get() {
+                        Some(span) => {
+                            let dups = self.dup_cache.entry(arg.get_ref().clone()).or_insert_with(|| (*span, Vec::new()));
+                            dups.1.push(arg.to_span());
+                            Ok(())
+                        },
+                        None => Err(FieldError::ReservedParameter)
+                    }
+                }
+            }
+        }
+
+        fn into_duplicates<S: 'static + FnMut(T) -> String>(self, mut stringify: S) -> impl Iterator<Item=ValidationError> {
+            self.dup_cache.into_iter().map(move |(name, (first_span, duplicate_spans))| {
+                ValidationError {
+                    source: ValidationErrorSource::Duplicates {
+                        name: stringify(name),
+                        first_span,
+                        duplicate_spans,
+                    }
+                }
+            })
+        }
+    }
+
+    impl ArgValidator<String> {
+        fn check_insert_long(&mut self, arg: &Spanned<String>) -> Result<(), ValidationError> {
+            self.check_insert(arg).field_name(arg)
+        }
+
+        fn check_insert_opt_long(&mut self, arg: &Option<Spanned<String>>) -> Result<(), ValidationError> {
+            if let Some(arg) = arg {
+                self.check_insert_long(arg)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub trait IntoParts: Sized {
+        type Value;
+
+        fn into_parts(self) -> (Self::Value, Span);
+        fn to_span(&self) -> Span;
+        fn get(&self) -> Self::Value where Self::Value: Copy;
+
+        fn to_parts(&self) -> (Self::Value, Span) where Self::Value: Copy {
+            (self.get(), self.to_span())
+        }
+    }
+
+    impl<T> IntoParts for Spanned<T> {
+        type Value = T;
+
+        fn into_parts(self) -> (Self::Value, Span) {
+            let span = Span::from(&self);
+            (self.into_inner(), span)
+        }
+
+        fn to_span(&self) -> Span {
+            Span::from(self)
+        }
+
+        fn get(&self) -> Self::Value where Self::Value: Copy {
+            *self.get_ref()
         }
     }
 
@@ -168,7 +525,7 @@ pub mod raw {
         #[serde(default)]
         pub switches: Vec<Switch>,
         #[serde(default)]
-        general: super::General,
+        general: General,
         #[serde(default)]
         defaults: super::Defaults,
         #[cfg(feature = "debconf")]
@@ -176,53 +533,70 @@ pub mod raw {
     }
 
     impl Config {
-        pub fn validate(self) -> Result<super::Config, ValidationError> {
-            // just for checking order/determinism doesn't matter
-            use std::collections::HashSet;
-
-            fn check_insert(long_args: &mut HashSet<Ident>, arg: &Ident) -> Result<(), ValidationError> {
-                if long_args.insert(arg.clone()) {
-                    Ok(())
-                } else {
-                    Err(ValidationErrorKind::Duplicate).field_name(&arg)
-                }
-            }
-
-            fn check_insert_opt(long_args: &mut HashSet<Ident>, arg: &Option<Ident>) -> Result<(), ValidationError> {
-                if let Some(arg) = arg {
-                    check_insert(long_args, arg)
-                } else {
-                    Ok(())
-                }
-            }
-
+        pub fn validate(self) -> Result<super::Config, Vec<ValidationError>> {
             let default_optional = self.defaults.optional;
             let default_argument = self.defaults.args;
             let default_env_var = self.defaults.env_vars.unwrap_or(self.general.env_prefix.is_some());
-            let mut long_args = HashSet::new();
-            long_args.insert(Ident::try_from("help".to_owned()).unwrap());
-            check_insert_opt(&mut long_args, &self.general.conf_file_param)?;
-            check_insert_opt(&mut long_args, &self.general.conf_dir_param)?;
-            check_insert_opt(&mut long_args, &self.general.skip_default_conf_files_switch)?;
+            let mut errors = Vec::new();
+            let mut long_args = ArgValidator::with_reserved("help".to_owned());
+            let mut short_args = ArgValidator::with_reserved('h');
+
+            long_args.check_insert_opt_long(&self.general.conf_file_param).unwrap_or_else(|error| errors.push(error));
+            long_args.check_insert_opt_long(&self.general.conf_dir_param).unwrap_or_else(|error| errors.push(error));
+            long_args.check_insert_opt_long(&self.general.skip_default_conf_files_switch).unwrap_or_else(|error| errors.push(error));
 
             let params = self.params
                 .into_iter()
-                .map(|param| {
-                    check_insert(&mut long_args, &param.name)?;
-                    param.validate(default_optional, default_argument, default_env_var)
+                .filter_map(|param| {
+                    long_args.check_insert_long(&param.name).unwrap_or_else(|error| errors.push(error));
+                    if let Some(abbr) = &param.abbr {
+                        short_args.check_insert(abbr).field_name(&param.name).unwrap_or_else(|error| errors.push(error));
+                    }
+                    param.validate(default_optional, default_argument, default_env_var).map_err(|error| errors.extend(error)).ok()
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Vec<_>>();
 
             let switches = self.switches
                 .into_iter()
-                .map(|switch| {
-                    check_insert(&mut long_args, &switch.name)?;
-                    switch.validate(default_env_var)
+                .filter_map(|switch| {
+                    long_args.check_insert_long(&switch.name).unwrap_or_else(|error| errors.push(error));
+                    if let Some(abbr) = &switch.abbr {
+                        short_args.check_insert(abbr).field_name(&switch.name).unwrap_or_else(|error| errors.push(error));
+                    }
+                    switch.validate(default_env_var).map_err(|error| errors.extend(error)).ok()
                 })
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Vec<_>>();
+
+            errors.extend(long_args.into_duplicates(std::convert::identity));
+            errors.extend(short_args.into_duplicates(|c| c.to_string()));
+
+            let mut to_ident = |opt: Option<Spanned<String>>| {
+                opt.and_then(|string| {
+                    Ident::try_from(string).map_err(|error| errors.push(error.into())).ok()
+                })
+            };
+
+            let conf_file_param = to_ident(self.general.conf_file_param);
+            let conf_dir_param = to_ident(self.general.conf_dir_param);
+            let skip_default_conf_files_switch = to_ident(self.general.skip_default_conf_files_switch);
+
+            if !errors.is_empty() {
+                errors.sort_by_key(ValidationError::sort_key);
+                return Err(errors);
+            }
+
+            let general = super::General {
+                name: self.general.name,
+                summary: self.general.summary,
+                doc: self.general.doc,
+                env_prefix: self.general.env_prefix,
+                conf_file_param,
+                conf_dir_param,
+                skip_default_conf_files_switch,
+            };
 
             Ok(super::Config {
-                general: self.general,
+                general,
                 defaults: self.defaults,
                 params,
                 switches,
@@ -233,15 +607,29 @@ pub mod raw {
     }
 
     #[derive(Debug)]
+    #[derive(Deserialize, Default)]
+    #[serde(deny_unknown_fields)]
+    pub struct General {
+        name: Option<String>,
+        summary: Option<String>,
+        doc: Option<String>,
+        env_prefix: Option<String>,
+        conf_file_param: Option<Spanned<String>>,
+        conf_dir_param: Option<Spanned<String>>,
+        skip_default_conf_files_switch: Option<Spanned<String>>,
+    }
+
+
+    #[derive(Debug)]
     #[derive(Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct Param {
-        name: Ident,
-        abbr: Option<char>,
+        name: Spanned<String>,
+        abbr: Option<Spanned<char>>,
         #[serde(rename = "type")]
         ty: String,
-        optional: Option<bool>,
-        default: Option<String>,
+        optional: Option<Spanned<bool>>,
+        default: Option<Spanned<String>>,
         doc: Option<String>,
         argument: Option<bool>,
         env_var: Option<bool>,
@@ -254,20 +642,26 @@ pub mod raw {
     }
 
     impl Param {
-        fn validate_optionality(optional: Option<bool>, default_optional: bool, default: Option<String>) -> Result<Optionality, ValidationErrorKind> {
+        fn validate_optionality(optional: Option<Spanned<bool>>, default_optional: bool, default: Option<Spanned<String>>) -> Result<Optionality, FieldError> {
             match (optional, default_optional, default) {
-                (Some(false), _, None) => Ok(Optionality::Mandatory),
-                (Some(false), _, Some(_)) => Err(ValidationErrorKind::MandatoryWithDefault),
-                (Some(true), _, None) => Ok(Optionality::Optional),
-                (_, _, Some(default)) => Ok(Optionality::DefaultValue(default)),
+                (Some(opt), _, None) if !opt.get() => Ok(Optionality::Mandatory),
+                (Some(opt), _, Some(default)) if !opt.get() => Err(FieldError::MandatoryWithDefault { optional_span: opt.to_span(), default_span: default.to_span(), }),
+                (Some(_), _, None) => Ok(Optionality::Optional),
+                (_, _, Some(default)) => Ok(Optionality::DefaultValue(default.into_inner())),
                 (None, true, None) => Ok(Optionality::Optional),
                 (None, false, None) => Ok(Optionality::Mandatory),
             }
         }
 
-        fn validate(self, default_optional: bool, default_argument: bool, default_env_var: bool) -> Result<super::Param, ValidationError> {
+        fn validate(self, default_optional: bool, default_argument: bool, default_env_var: bool) -> Result<super::Param, impl Iterator<Item=ValidationError>> {
             let optionality = Param::validate_optionality(self.optional, default_optional, self.default)
-                .field_name(&self.name)?;
+                .field_name(&self.name);
+            let name = Ident::try_from(self.name).map_err(Into::into);
+
+            let (name, optionality) = match (name, optionality) {
+                (Ok(name), Ok(optionality)) => (name, optionality),
+                (err1, err2) => return Err(err1.err().into_iter().chain(err2.err())),
+            };
 
             let ty = self.ty;
             let argument = self.argument.unwrap_or(default_argument);
@@ -275,10 +669,10 @@ pub mod raw {
             let convert_into = self.convert_into.unwrap_or_else(|| ty.clone());
 
             Ok(super::Param {
-                name: self.name,
+                name,
                 ty,
                 optionality,
-                abbr: self.abbr,
+                abbr: self.abbr.map(Spanned::into_inner),
                 doc: self.doc,
                 argument,
                 env_var,
@@ -296,47 +690,59 @@ pub mod raw {
     #[derive(Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct Switch {
-        name: Ident,
-        abbr: Option<char>,
-        #[serde(default)]
-        default: bool,
+        name: Spanned<String>,
+        abbr: Option<Spanned<char>>,
+        default: Option<Spanned<bool>>,
         doc: Option<String>,
         env_var: Option<bool>,
-        #[serde(default)]
-        count: bool,
+        count: Option<Spanned<bool>>,
         #[cfg(feature = "debconf")]
         debconf_priority: Option<::debconf::Priority>,
     }
 
     impl Switch {
-        fn validate_abbr(abbr: char) -> Result<char, ValidationErrorKind> {
+        fn validate_abbr(spanned_abbr: Spanned<char>) -> Result<Spanned<char>, FieldError> {
+            let (abbr, abbr_span) = spanned_abbr.to_parts();
             if (abbr >= 'a' && abbr <= 'z') || (abbr >= 'A' && abbr <= 'Z') {
-                Ok(abbr)
+                Ok(spanned_abbr)
             } else {
-                Err(ValidationErrorKind::InvalidAbbr)
+                Err(FieldError::InvalidAbbr { abbr_span, })
             }
         }
 
-        fn validate_kind(abbr: Option<char>, default: bool, count: bool) -> Result<SwitchKind, ValidationErrorKind> {
+        fn validate_kind(abbr: Option<Spanned<char>>, default: Option<Spanned<bool>>, count: Option<Spanned<bool>>) -> Result<SwitchKind, FieldError> {
             match (abbr, default, count) {
-                (Some(_), true, _) => Err(ValidationErrorKind::InvertedWithAbbr),
-                (_, true, true) => Err(ValidationErrorKind::InvertedWithCount),
-                (None, true, false) => Ok(SwitchKind::Inverted),
-                (abbr, false, count) => Ok(SwitchKind::Normal { abbr, count }),
+                (Some(abbr), Some(default), _) if default.get() => Err(FieldError::InvertedWithAbbr { abbr_span: abbr.to_span(), default_span: default.to_span() }),
+                (_, Some(default), Some(count)) if default.get() && count.get() => Err(FieldError::InvertedWithCount { default_span: default.to_span(), count_span: count.to_span() }),
+                (None, Some(default), _) if default.get() => Ok(SwitchKind::Inverted),
+                (abbr, _, count) => Ok(SwitchKind::Normal { abbr: abbr.map(Spanned::into_inner), count: count.map(Spanned::into_inner).unwrap_or(false) }),
             }
         }
 
-        fn validate(self, default_env_var: bool) -> Result<super::Switch, ValidationError> {
-            let abbr = self.abbr
+        fn validate(self, default_env_var: bool) -> Result<super::Switch, impl Iterator<Item=ValidationError>> {
+            let abbr = self.abbr;
+            let default = self.default;
+            let count = self.count;
+            let name = &self.name;
+
+            let kind = abbr
                 .map(Switch::validate_abbr)
                 .transpose()
-                .field_name(&self.name)?;
+                .field_name(name)
+                .and_then(|abbr| {
+                    Switch::validate_kind(abbr, default, count)
+                        .field_name(name)
+                });
 
-            let kind = Switch::validate_kind(abbr, self.default, self.count)
-                .field_name(&self.name)?;
+            let name = Ident::try_from(self.name).map_err(Into::into);
+
+            let (name, kind) = match (name, kind) {
+                (Ok(name), Ok(kind)) => (name, kind),
+                (err1, err2) => return Err(err1.err().into_iter().chain(err2.err())),
+            };
 
             Ok(super::Switch {
-                name: self.name,
+                name,
                 kind,
                 doc: self.doc,
                 env_var: self.env_var.unwrap_or(default_env_var),
@@ -360,9 +766,7 @@ pub struct Config {
     pub switches: Vec<Switch>,
 }
 
-#[derive(Debug)]
-#[derive(Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Default)]
 pub struct General {
     /// Name of the program
     pub name: Option<String>,

--- a/configure_me_codegen/tests/error.rs
+++ b/configure_me_codegen/tests/error.rs
@@ -1,0 +1,173 @@
+#[cfg(feature = "codespan-reporting")]
+#[test]
+fn codespan_report() {
+    let toml = r#"
+        [general]
+        conf_file_param = "foo"
+        conf_dir_param = "foo"
+        skip_default_conf_files_switch = "help"
+
+        [[param]]
+        name = "bar"
+        type = "bool"
+        default = "false"
+        abbr = "x"
+        optional = false
+
+        [[switch]]
+        name = "foo"
+        abbr = "x"
+
+        [[switch]]
+        name = "foo"
+        abbr = "x"
+
+        [[switch]]
+        name = "baz"
+        abbr = "-"
+
+        [[switch]]
+        name = "0foo"
+
+        [[switch]]
+        name = "-foo"
+
+        [[switch]]
+        name = "foo-bar"
+
+        [[switch]]
+        name = "1a=bit**loong   and ###weird@parameter"
+
+        [[switch]]
+        name = "-a=bit**loong   and ###weird@parameter"
+
+        [[switch]]
+        name = "a=bit**loong   and ###weird@parameter"
+        "#;
+
+    let expected = r#"invalid config specification:
+error: the option `foo` appears more than once
+   ┌─ unknown file:4:26
+   │
+ 3 │         conf_file_param = "foo"
+   │                           ----- the option was first defined here
+ 4 │         conf_dir_param = "foo"
+   │                          ^^^^^ the option is repeated here
+   ·
+15 │         name = "foo"
+   │                ^^^^^ ... and here
+   ·
+19 │         name = "foo"
+   │                ^^^^^ ... and here
+
+error: use of reserved option
+  ┌─ unknown file:5:42
+  │
+5 │         skip_default_conf_files_switch = "help"
+  │                                          ^^^^^^ this option is reserved because it's always implemented by `configure_me`
+
+error: parameter attempts to be both optional and mandatory at the same time
+   ┌─ unknown file:10:19
+   │
+ 8 │         name = "bar"
+   │                ----- in the parameter `bar`
+ 9 │         type = "bool"
+10 │         default = "false"
+   │                   ^^^^^^^ the default value is provided here making the parameter optional
+11 │         abbr = "x"
+12 │         optional = false
+   │                    ^^^^^ setting `optional` to `false` makes the parameter mandatory here
+   │
+   = Help: either make the parameter optional or remove the default value
+
+error: the option `x` appears more than once
+   ┌─ unknown file:16:16
+   │
+11 │         abbr = "x"
+   │                --- the option was first defined here
+   ·
+16 │         abbr = "x"
+   │                ^^^ the option is repeated here
+   ·
+20 │         abbr = "x"
+   │                ^^^ ... and here
+
+error: invalid short option
+   ┌─ unknown file:24:16
+   │
+23 │         name = "baz"
+   │                ----- in this field
+24 │         abbr = "-"
+   │                ^^^ this option uses an invalid character
+   │
+   = Note: only English letters (both lower case and upper case) are allowed
+
+error: the identifier `0foo` contains an invalid character
+   ┌─ unknown file:27:17
+   │
+27 │         name = "0foo"
+   │                 ^ the identifier starts with a digit
+   │
+   = Help: identifiers mut not start with digits
+
+error: the identifier `-foo` contains an invalid character
+   ┌─ unknown file:30:17
+   │
+30 │         name = "-foo"
+   │                 ^ this char is invalid
+   │
+   = Help: dashes are prepended automatically, you don't need to write them
+
+error: the identifier `foo-bar` contains an invalid character
+   ┌─ unknown file:33:20
+   │
+33 │         name = "foo-bar"
+   │                    ^ this char is invalid
+   │
+   = Help: consider replacing dashes with underscores.
+           They will be replaced with dashes in command line parameters
+           but stay underscores in config files.
+
+error: the identifier `1a=bit**loong   and ###weird@parameter` contains invalid characters
+   ┌─ unknown file:36:17
+   │
+36 │         name = "1a=bit**loong   and ###weird@parameter"
+   │                 ^ ^   ^^     ^^^   ^^^^     ^ ... and this char
+   │                 │ │   │      │     │         
+   │                 │ │   │      │     ... and these chars
+   │                 │ │   │      ... and these chars
+   │                 │ │   ... and these chars
+   │                 │ this char is invalid
+   │                 the identifier starts with a digit
+   │
+   = Help: identifiers mut not start with digits
+
+error: the identifier `-a=bit**loong   and ###weird@parameter` contains invalid characters
+   ┌─ unknown file:39:17
+   │
+39 │         name = "-a=bit**loong   and ###weird@parameter"
+   │                 ^ ^   ^^     ^^^   ^^^^     ^ ... and this char
+   │                 │ │   │      │     │         
+   │                 │ │   │      │     ... and these chars
+   │                 │ │   │      ... and these chars
+   │                 │ │   ... and these chars
+   │                 │ ... and this char
+   │                 this char is invalid
+   │
+   = Help: dashes are prepended automatically, you don't need to write them
+
+error: the identifier `a=bit**loong   and ###weird@parameter` contains invalid characters
+   ┌─ unknown file:42:18
+   │
+42 │         name = "a=bit**loong   and ###weird@parameter"
+   │                  ^   ^^     ^^^   ^^^^     ^ ... and this char
+   │                  │   │      │     │         
+   │                  │   │      │     ... and these chars
+   │                  │   │      ... and these chars
+   │                  │   ... and these chars
+   │                  this char is invalid
+
+"#;
+    let error_messages = format!("{:?}", configure_me_codegen::generate_source(toml.as_bytes(), std::io::sink()).unwrap_err());
+    assert_eq!(error_messages, expected);
+}


### PR DESCRIPTION
One of the challenges of `configure_me` is its usage being less common. Good error messages, among other things, can make development easier and may help people understand `configure_me` better.

This makes several significant improvements of error messages:

* Uses `codespan-reporting` to report the exact places of root causes of errors - the messages look very similar to those of rustc!
* Doesn't stop after first validation error - if multiple errors can be detected and reported they are.
* Moves identifier validation out of deserialization to allow detecting other errors and print very detailed messages with hints.
* Treats `--help`/`-h` as reserved and reports it as such.
* Adds detection of duplicate short options - this was previously missing.
* Spanned messages don't just report the locations but also explain possibly less-obvious details - such as setting `default = true` in switch makes it inverted.
* Improves wording of some messages.

**New API and new style of build script**

`Error` has new methods `report` and `report_and_exit` that report the error with colors to stderr. The latter one is intended for use in build script inside `unwrap_or_else`:

```rust
fn main() {
    configure_me_codegen::build_script_auto()
        .unwrap_or_else(|error| error.report_and_exit());
}
```

The addition of `unwrap_or_else` is offset by removal of `-> Result<...>`. Note that the existing build scripts still work, they are just colorless.