### PR TITLE
Ranged versions of `cargo_toml`

### DIFF
--- a/configure_me_codegen/Cargo.toml
+++ b/configure_me_codegen/Cargo.toml
@@ -21,7 +21,7 @@ unstable-metabuild = []
 serde = "1.0.101"
 serde_derive = "1.0.101"
 toml = "0.5.4"
-cargo_toml = "0.12.0"
+cargo_toml = ">= 0.12.4, < 0.21.0"
 unicode-segmentation = "1.2"
 fmt2io = "0.1"
 void = "1"

--- a/configure_me_codegen/src/lib.rs
+++ b/configure_me_codegen/src/lib.rs
@@ -673,6 +673,7 @@ r#"
 program_name = "required"
 "#;
 
+    #[allow(unused)]
     pub struct ExpectedOutput {
         pub raw_config: &'static str,
         pub validate: &'static str,


### PR DESCRIPTION
This mainly changes the `cargo_toml` version to a range.

Replaces #61 
Closes #60 